### PR TITLE
Refactor: extract collision math/constants and add tests for stepBallFrame

### DIFF
--- a/src/engine/collision.ts
+++ b/src/engine/collision.ts
@@ -1,5 +1,11 @@
 import type { Vector3Tuple } from 'three';
-import type { Ball, Brick } from '../store/gameStore';
+import type { Ball, Brick } from '../store/types';
+import { BRICK_SIZE } from './collision/constants';
+import {
+  clampDelta as clampDeltaImpl,
+  reflectIfOutOfBounds as reflectIfOutOfBoundsImpl,
+  resolveBrickCollision as resolveBrickCollisionImpl,
+} from './collision/math';
 
 export interface ArenaSize {
   width: number;
@@ -20,50 +26,11 @@ export interface BallFrameResult {
   hitBrickId?: string;
 }
 
-export const clampDelta = (delta: number) => Math.min(delta, 0.05);
+export const clampDelta = clampDeltaImpl;
 
-const reflectIfOutOfBounds = (position: number, limit: number) => {
-  if (position < -limit || position > limit) {
-    const clamped = Math.max(-limit, Math.min(limit, position));
-    return { reflected: true, value: clamped };
-  }
-  return { reflected: false, value: position };
-};
+const reflectIfOutOfBounds = reflectIfOutOfBoundsImpl;
 
-const resolveBrickCollision = (
-  target: { x: number; y: number; z: number; radius: number },
-  brick: Brick
-) => {
-  const dx = target.x - brick.position[0];
-  const dy = target.y - brick.position[1];
-  const dz = target.z - brick.position[2];
-
-  const closestX = Math.max(-BRICK_HALF_SIZE.x, Math.min(BRICK_HALF_SIZE.x, dx));
-  const closestY = Math.max(-BRICK_HALF_SIZE.y, Math.min(BRICK_HALF_SIZE.y, dy));
-  const closestZ = Math.max(-BRICK_HALF_SIZE.z, Math.min(BRICK_HALF_SIZE.z, dz));
-
-  const distX = dx - closestX;
-  const distY = dy - closestY;
-  const distZ = dz - closestZ;
-  const distance = Math.sqrt(distX * distX + distY * distY + distZ * distZ);
-
-  if (distance >= target.radius) {
-    return { hit: false as const };
-  }
-
-  const absDistX = Math.abs(distX);
-  const absDistY = Math.abs(distY);
-  const absDistZ = Math.abs(distZ);
-
-  if (absDistX >= absDistY && absDistX >= absDistZ) {
-    return { hit: true as const, axis: 'x' as const, brickId: brick.id };
-  }
-  if (absDistY >= absDistX && absDistY >= absDistZ) {
-    return { hit: true as const, axis: 'y' as const, brickId: brick.id };
-  }
-
-  return { hit: true as const, axis: 'z' as const, brickId: brick.id };
-};
+const resolveBrickCollision = resolveBrickCollisionImpl;
 
 export const stepBallFrame = (
   ball: Ball,
@@ -134,3 +101,5 @@ export const stepBallFrame = (
     hitBrickId,
   };
 };
+
+export { BRICK_SIZE };

--- a/src/engine/collision/constants.ts
+++ b/src/engine/collision/constants.ts
@@ -1,0 +1,7 @@
+export const BRICK_SIZE = { x: 1.5, y: 0.8, z: 1 };
+
+export const BRICK_HALF_SIZE = {
+  x: BRICK_SIZE.x / 2,
+  y: BRICK_SIZE.y / 2,
+  z: BRICK_SIZE.z / 2,
+};

--- a/src/engine/collision/math.ts
+++ b/src/engine/collision/math.ts
@@ -1,0 +1,47 @@
+import type { Brick } from '../../store/types';
+import { BRICK_HALF_SIZE } from './constants';
+
+export const clampDelta = (delta: number) => Math.min(delta, 0.05);
+
+export const reflectIfOutOfBounds = (position: number, limit: number) => {
+  if (position < -limit || position > limit) {
+    const clamped = Math.max(-limit, Math.min(limit, position));
+    return { reflected: true, value: clamped };
+  }
+  return { reflected: false, value: position };
+};
+
+export const resolveBrickCollision = (
+  target: { x: number; y: number; z: number; radius: number },
+  brick: Brick
+) => {
+  const dx = target.x - brick.position[0];
+  const dy = target.y - brick.position[1];
+  const dz = target.z - brick.position[2];
+
+  const closestX = Math.max(-BRICK_HALF_SIZE.x, Math.min(BRICK_HALF_SIZE.x, dx));
+  const closestY = Math.max(-BRICK_HALF_SIZE.y, Math.min(BRICK_HALF_SIZE.y, dy));
+  const closestZ = Math.max(-BRICK_HALF_SIZE.z, Math.min(BRICK_HALF_SIZE.z, dz));
+
+  const distX = dx - closestX;
+  const distY = dy - closestY;
+  const distZ = dz - closestZ;
+  const distance = Math.sqrt(distX * distX + distY * distY + distZ * distZ);
+
+  if (distance >= target.radius) {
+    return { hit: false as const };
+  }
+
+  const absDistX = Math.abs(distX);
+  const absDistY = Math.abs(distY);
+  const absDistZ = Math.abs(distZ);
+
+  if (absDistX >= absDistY && absDistX >= absDistZ) {
+    return { hit: true as const, axis: 'x' as const, brickId: brick.id };
+  }
+  if (absDistY >= absDistX && absDistY >= absDistZ) {
+    return { hit: true as const, axis: 'y' as const, brickId: brick.id };
+  }
+
+  return { hit: true as const, axis: 'z' as const, brickId: brick.id };
+};

--- a/src/test/collision.test.ts
+++ b/src/test/collision.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { stepBallFrame } from '../engine/collision';
+
+describe('stepBallFrame - walls and bricks', () => {
+  it('reflects off X wall and clamps position', () => {
+    const arena = { width: 12, height: 10, depth: 8 };
+    const radius = 0.3;
+    const boundsX = arena.width / 2 - radius;
+
+    const ball = {
+      id: 'ball-wall',
+      position: [boundsX - 0.1, 0, 0],
+      velocity: [1, 0, 0],
+      radius,
+      damage: 1,
+      color: '#fff',
+    } as any;
+
+    const result = stepBallFrame(ball, 1 /* delta */, arena, []);
+
+    expect(result.nextPosition[0]).toBeLessThanOrEqual(boundsX + 1e-6);
+    expect(result.nextVelocity[0]).toBeLessThan(0);
+  });
+
+  it('detects brick collision and inverts axis velocity', () => {
+    const arena = { width: 12, height: 10, depth: 8 };
+
+    const brick = {
+      id: 'brick-1',
+      position: [0, 0, 0],
+      health: 10,
+      maxHealth: 10,
+      color: '#fff',
+      value: 10,
+    } as any;
+
+    const ball = {
+      id: 'ball-1',
+      position: [-0.1, 0, 0],
+      velocity: [0.2, 0, 0],
+      radius: 0.5,
+      damage: 1,
+      color: '#fff',
+    } as any;
+
+    const result = stepBallFrame(ball, 0.016, arena, [brick]);
+
+    expect(result.hitBrickId).toBe(brick.id);
+    expect(result.nextVelocity[0]).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
This PR extracts collision math helpers and constants into separate modules and adds unit tests for stepBallFrame.\n\nFiles changed:\n- src/engine/collision/constants.ts\n- src/engine/collision/math.ts\n- src/engine/collision.ts\n- src/test/collision.test.ts\n\nPart of the planned refactor: extract pure engine math to improve testability.