### PR TITLE
Refactor type imports to use centralized types

### DIFF
--- a/src/components/Ball.tsx
+++ b/src/components/Ball.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 import type { Mesh } from 'three';
-import type { Ball as BallType } from '../store/gameStore';
+import type { Ball as BallType } from '../store/types';
 
 interface BallProps {
   ball: BallType;

--- a/src/components/Brick.tsx
+++ b/src/components/Brick.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import type { Mesh } from 'three';
-import type { Brick as BrickType } from '../store/gameStore';
+import type { Brick as BrickType } from '../store/types';
 
 interface BrickProps {
   brick: BrickType;

--- a/src/components/bricks/BricksInstanced.tsx
+++ b/src/components/bricks/BricksInstanced.tsx
@@ -1,4 +1,4 @@
-import type { Brick } from '../../store/gameStore';
+import type { Brick } from '../../store/types';
 import { BRICK_SIZE } from '../../engine/collision';
 import { useInstancedBricks } from './useInstancedBricks';
 

--- a/src/components/bricks/useInstancedBricks.ts
+++ b/src/components/bricks/useInstancedBricks.ts
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useRef } from 'react';
 import { Color, Object3D, type InstancedMesh } from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import { getBrickFromInstance } from '../../engine/picking';
-import type { Brick } from '../../store/gameStore';
+import type { Brick } from '../../store/types';
 import { getDamageColor } from './utils';
 
 const tempObject = new Object3D();

--- a/src/components/bricks/utils.ts
+++ b/src/components/bricks/utils.ts
@@ -1,4 +1,4 @@
-import type { Brick } from '../../store/gameStore';
+import type { Brick } from '../../store/types';
 
 export const getDamageColor = (brick: Brick, isHovered: boolean) => {
   if (isHovered) return '#FFFFFF';

--- a/src/engine/picking.ts
+++ b/src/engine/picking.ts
@@ -1,4 +1,4 @@
-import type { Brick } from '../store/gameStore';
+import type { Brick } from '../store/types';
 
 export const getBrickFromInstance = (bricks: Brick[], instanceId: number | undefined | null) => {
   if (instanceId === null || instanceId === undefined) return null;

--- a/src/test/bricks.utils.test.ts
+++ b/src/test/bricks.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getDamageColor } from '../components/bricks/utils';
-import type { Brick } from '../store/gameStore';
+import type { Brick } from '../store/types';
 
 const makeBrick = (overrides: Partial<Brick> = {}): Brick => ({
   id: 'brick-1',


### PR DESCRIPTION
Update type imports to source from `src/store/types` instead of `gameStore`, promoting consistency and maintainability in the codebase.